### PR TITLE
Add PM2 startup script for server auto-restore after reboot or crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ Built in response to the ongoing humanitarian crisis in Gaza, this platform offe
 - `Prisma ORM` + `Neon DB (PostgreSQL)`
 - `Clerk` for authentication
 
+
+### 🧩 PM2 Auto-Restart Script
+The `/scripts/startup.sh` file ensures that PM2 automatically restores all processes
+after a server reboot. 
+
+### Usage
+To manually trigger the script (useful for testing):
+```bash
+bash scripts/startup.sh
+
+
+#### Automation
+
+To make sure it runs automatically after every reboot, add it to your crontab:
+
+```bash
+@reboot bash /home/gaza/htdocs/www.gaza.family/scripts/startup.sh >/dev/null 2>&1
+
+#### Notes
+
+> Make sure your .env file is properly configured before running.
+
+> Run pm2 save after starting your app to persist the process list.
+
+
+
 ## 🔄 Roadmap
 - MVP: Live app with map + dashboards + basic reports
 - Enable user-submitted reports (with moderation)

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+LOG_FILE="$HOME/pm2-startup.log"
+PROJECT_DIR="$HOME/htdocs/www.gaza.family"
+
+{
+  echo "[$(date)] Running PM2 startup check..."
+
+  # Load NVM and Node environment
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+  [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+
+  # Ensure Node is in PATH
+  export PATH="$HOME/.nvm/versions/node/v22.20.0/bin:$PATH"
+
+  cd "$PROJECT_DIR"
+
+  # Start PM2 daemon if not running
+  if ! pm2 ping >/dev/null 2>&1; then
+    echo "[$(date)] PM2 daemon not running. Starting PM2 and restoring processes..."
+    pm2 resurrect --update-env
+  else
+    echo "[$(date)] PM2 already running."
+  fi
+
+  # Ensure process list is saved (optional safeguard)
+  pm2 save
+} >> "$LOG_FILE" 2>&1


### PR DESCRIPTION
This PR adds a new `scripts/startup.sh` file to automate the PM2 process restoration
on server reboot in the GazaAidSync production environment.

**What’s included:**
- Bash script that ensures PM2 daemon is loaded, Node environment is initialized (via NVM), and processes are resurrected from dump.
- Logging setup to track script executions at `$HOME/pm2-startup.log`.
- Structured under `/scripts` for better organization.

**Why:**
This ensures the GazaAidSync app automatically comes back online after a system restart
without manual intervention.

**Tested on:**
Hostinger CloudPanel (Ubuntu 22.04)
